### PR TITLE
Support Dictionary<string,string> sections

### DIFF
--- a/Sini/IniFile.cs
+++ b/Sini/IniFile.cs
@@ -685,6 +685,15 @@ namespace Sini
             bool snakecase = (flags & ParseObjectFlags.SnakecaseKeysAndSections) != 0;
             if (lowercase && snakecase) { throw new ArgumentException("Can't have both 'LowercaseKeysAndSections' and 'SnakecaseKeysAndSections' flags set!"); }
 
+            if (instance.GetType() == typeof(Dictionary<string,string>) && section != null)
+            {
+                foreach (string key in ini.GetAllUnreadKeys().Where( s => s.StartsWith($"[{section}]") ).Select(x => x.Replace($"[{section}] ","")))
+                {
+                    (instance as Dictionary<string,string>)?.Add(key,ini.GetStr(section, key, null));
+                }
+                return;
+            }
+
             // iterate public fields and properties we can set
             var bindingFlags = BindingFlags.Public | BindingFlags.Instance;
             var propsAndFields = instance.GetType().GetFields(bindingFlags).Cast<MemberInfo>().Concat(instance.GetType().GetProperties(bindingFlags)).ToArray();


### PR DESCRIPTION
Hi Ronen,

I have a legacy project where one section is used as a `Dictionary<string,string>` with filters where key can be anything just as value can be anything.

This solution solves this for me, but I am unsure if it would break anything else. I mean, the code will only execute if the instance passed is a `Dictionary<string,string>`.

I am open for suggestions to improve this, so it can be upstreamed and added to NuGet, and I don't have to keep maintaining my own fork.

Thanks for your work, saved me the hassle of doing the same on my own!

Best regards,
Marlon Beijer